### PR TITLE
feat: Add convertStringToSlug utility

### DIFF
--- a/etc/plugin-config-ui-lib.api.md
+++ b/etc/plugin-config-ui-lib.api.md
@@ -57,6 +57,9 @@ export interface CloudQueryTable {
 export type CloudQueryTables = CloudQueryTable[];
 
 // @public
+export function convertStringToSlug(value: string): string;
+
+// @public
 export const ExclusiveToggle: ForwardRefExoticComponent<ExclusiveToggleProps & RefAttributes<HTMLElement>>;
 
 // @public (undocumented)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudquery/plugin-config-ui-lib",
-  "version": "0.0.60",
+  "version": "0.0.61",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudquery/plugin-config-ui-lib",
-      "version": "0.0.60",
+      "version": "0.0.61",
       "license": "MPL-2.0",
       "dependencies": {
         "@cloudquery/cloud-ui": "^0.1.13",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cloudquery/plugin-config-ui-lib",
   "description": "Plugin configuration UI library for CloudQuery Cloud App",
-  "version": "0.0.60",
+  "version": "0.0.61",
   "private": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/utils/convertStringToSlug.ts
+++ b/src/utils/convertStringToSlug.ts
@@ -1,0 +1,19 @@
+/**
+ * Converts an arbitrary string to a valid slug
+ *
+ * @param value - string argument to be converted to a slug
+ * @public
+ */
+export function convertStringToSlug(value: string) {
+  let slug = value
+    .toLowerCase()
+    .replace(/[^\da-z-]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  if (!/^[a-z]/.test(slug)) {
+    slug = `a${slug}`;
+  }
+
+  return slug;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,3 +8,4 @@ export { getRandomId } from './getRandomId';
 export { generatePluginTableList } from './generatePluginTableList';
 export { generateTablesFromJson } from './generateTablesFromJson';
 export { readSecretsFromInitialValues, writeSecretsToPrepareValues } from './processEnvSecrets';
+export { convertStringToSlug } from './convertStringToSlug';

--- a/src/utils/tests/convertStringToSlug.test.ts
+++ b/src/utils/tests/convertStringToSlug.test.ts
@@ -1,0 +1,14 @@
+import { convertStringToSlug } from '../convertStringToSlug';
+
+describe('convertStringToSlug', () => {
+    it('should generate the correct slug based on the input string', () => {
+        // Test case 1: already slug
+        expect(convertStringToSlug("test-slug")).toBe('test-slug')
+        // Test case 1: uppercase
+        expect(convertStringToSlug("Test")).toBe('test')
+        // Test case 1: with spaces
+        expect(convertStringToSlug("Test Slug")).toBe('test-slug')
+        // Test case 1: only numeric
+        expect(convertStringToSlug("1234")).toBe('a1234')
+    });
+});


### PR DESCRIPTION
This adds a `convertStringToSlug` utility to be used to convert `displayName`s to `name`s in plugin UIs