### PR TITLE
fix: Get by role instead of by text

### DIFF
--- a/src/e2e-utils/plugin-ui-e2e-helpers.ts
+++ b/src/e2e-utils/plugin-ui-e2e-helpers.ts
@@ -47,7 +47,7 @@ export const createPlugin = async ({
   test.setTimeout(300_000);
   await page.goto(getRootUrl());
 
-  await expect(page.getByText(`Create a ${kind}`)).toBeVisible();
+  await expect(page.getByRole('heading', { name: `Create a ${kind}` })).toBeVisible();
 
   await fillInput(page, 'input[type="text"]', pluginName);
 
@@ -90,7 +90,7 @@ export const editPlugin = async ({
   test.setTimeout(300_000);
   await page.goto(getRootUrl());
 
-  await expect(page.getByText(`Create a ${kind}`)).toBeVisible();
+  await expect(page.getByRole('heading', { name: `Create a ${kind}` })).toBeVisible();
 
   await fillInput(page, 'input[type="text"]', pluginName);
 
@@ -139,7 +139,7 @@ export const deletePlugin = async ({
   test.setTimeout(300_000);
   await page.goto(getRootUrl());
 
-  await expect(page.getByText(`Create a ${kind}`)).toBeVisible();
+  await expect(page.getByRole('heading', { name: `Create a ${kind}` })).toBeVisible();
 
   await fillInput(page, 'input[type="text"]', pluginName);
 


### PR DESCRIPTION
This attempts to fix the following selector error in the create, edit and delete phases of the e2e tests:

```
  1) [chromium] › postgresql.spec.ts:26:7 › PostgreSQL Destination › create plugin ─────────────────

    Error: expect.toBeVisible: Error: strict mode violation: getByText('Create a destination') resolved to 2 elements:
        1) <h4 class="MuiTypography-root MuiTypography-h4 css-nl5vyw">Create a destination</h4> aka getByRole('heading', { name: 'Create a destination' })
        2) <p role="alert" aria-live="assertive" id="__next-route-announcer__">CloudQuery | Create a Destination</p> aka getByText('CloudQuery | Create a')
```
