### PR TITLE
fix: styling of CodeSnippet copy button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudquery/plugin-config-ui-lib",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudquery/plugin-config-ui-lib",
-      "version": "3.0.4",
+      "version": "3.0.5",
       "license": "MPL-2.0",
       "dependencies": {
         "@babel/runtime": "^7.25.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cloudquery/plugin-config-ui-lib",
   "description": "Plugin configuration UI library for CloudQuery Cloud App",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "private": false,
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/components/display/codeSnippet/index.tsx
+++ b/src/components/display/codeSnippet/index.tsx
@@ -32,7 +32,16 @@ export function CodeSnippet({ text }: CodeSnippetProps) {
   return (
     <Box
       sx={{
-        '& pre': { whiteSpace: 'break-spaces', outline: 'none', margin: 1.5, fontSize: '12px' },
+        display: 'flex',
+        alignItems: 'center',
+        minHeight: '40px',
+        '& pre': {
+          whiteSpace: 'break-spaces',
+          outline: 'none',
+          margin: 1.5,
+          fontSize: '12px',
+          paddingRight: '40px',
+        },
         '& .value': { color: palette.text.secondary },
         '& .key': { color: palette.info.main },
         position: 'relative',


### PR DESCRIPTION
in case the code snippet is only a single line, set minimum height and center align the text and copy button