### PR TITLE
fix: Type plugin label in tests, rather than name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudquery/plugin-config-ui-lib",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudquery/plugin-config-ui-lib",
-      "version": "3.0.5",
+      "version": "3.0.6",
       "license": "MPL-2.0",
       "dependencies": {
         "@babel/runtime": "^7.25.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cloudquery/plugin-config-ui-lib",
   "description": "Plugin configuration UI library for CloudQuery Cloud App",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "private": false,
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/e2e-utils/plugin-ui-e2e-helpers.ts
+++ b/src/e2e-utils/plugin-ui-e2e-helpers.ts
@@ -49,7 +49,7 @@ export const createPlugin = async ({
 
   await expect(page.getByRole('heading', { name: `Create a ${kind}` })).toBeVisible();
 
-  await fillInput(page, 'input[type="text"]', pluginName);
+  await fillInput(page, 'input[type="text"]', pluginLabel);
 
   await click(page, page.getByRole('button', { name: pluginLabel }));
 
@@ -92,7 +92,7 @@ export const editPlugin = async ({
 
   await expect(page.getByRole('heading', { name: `Create a ${kind}` })).toBeVisible();
 
-  await fillInput(page, 'input[type="text"]', pluginName);
+  await fillInput(page, 'input[type="text"]', pluginLabel);
 
   await click(page, page.getByRole('button', { name: pluginLabel }));
   await expect(page.getByText('Previewing')).toBeVisible();
@@ -141,7 +141,7 @@ export const deletePlugin = async ({
 
   await expect(page.getByRole('heading', { name: `Create a ${kind}` })).toBeVisible();
 
-  await fillInput(page, 'input[type="text"]', pluginName);
+  await fillInput(page, 'input[type="text"]', pluginLabel);
 
   await click(page, page.getByRole('button', { name: pluginLabel }));
   await expect(page.getByText('Previewing')).toBeVisible();

--- a/src/e2e-utils/plugin-ui-e2e-helpers.ts
+++ b/src/e2e-utils/plugin-ui-e2e-helpers.ts
@@ -7,8 +7,18 @@ export const getPersistentName = () => `name-${Math.random().toString(36).slice(
 type CreatePluginControlOpts = {
   page: Page;
   kind: 'source' | 'destination';
-  pluginName: string;
+  /**
+   * @deprecated - This property is no longer used in the test functions. It is the api identifier
+   * for the plugin (ie. `google-search-console`)
+   */
+  pluginName?: string;
+  /**
+   * User readable label of the plugin (ie. 'Google Search Console' for 'google-search-console')
+   */
   pluginLabel: string;
+  /**
+   * Desired user input for the `Source name` or `Destination name` input field.
+   */
   pluginNewName: string;
   fillFieldsSteps?: (iframeElement: Frame) => Promise<void>;
 };
@@ -39,7 +49,6 @@ export const login = async (page: Page) => {
 export const createPlugin = async ({
   page,
   kind,
-  pluginName,
   pluginNewName,
   pluginLabel,
   fillFieldsSteps,
@@ -82,7 +91,6 @@ export const editPlugin = async ({
   page,
   kind,
   pluginNewName,
-  pluginName,
   pluginLabel,
   fillFieldsSteps,
   pluginUrl,
@@ -132,7 +140,6 @@ export const deletePlugin = async ({
   page,
   kind,
   pluginNewName,
-  pluginName,
   pluginLabel,
   pluginUrl,
 }: EditPluginControlOpts) => {


### PR DESCRIPTION
I had an issue with the `Google Search Console` plugin where the input being typed was `google-search-console`: 

<img width="579" alt="Screenshot 2024-10-02 at 14 59 10" src="https://github.com/user-attachments/assets/1e356e57-d6ff-4f4b-b6ca-a9b981cf46f6">

I have kept the interface the same, despite no longer using plugin name. Happy to hear your thoughts. I could also just pass `Google Search Console` in as the name to fix my tests, but that doesn't seem right