### PR TITLE
Disable scroll lock for select field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudquery/plugin-config-ui-lib",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudquery/plugin-config-ui-lib",
-      "version": "7.0.3",
+      "version": "7.0.4",
       "license": "MPL-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cloudquery/plugin-config-ui-lib",
   "description": "Plugin configuration UI library for CloudQuery Cloud App",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "private": false,
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/components/form/controls/controlSelectField.tsx
+++ b/src/components/form/controls/controlSelectField.tsx
@@ -47,6 +47,7 @@ export function ControlSelectField({
           slotProps={{
             select: {
               MenuProps: {
+                disableScrollLock: true,
                 autoFocus: false,
                 disableAutoFocus: true,
               },


### PR DESCRIPTION
Scroll lock breaks sticky position of the guide causing it to disappear when select options are shown