### PR TITLE
Allow plugin version to be set outside on Vercel and dev environments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudquery/plugin-config-ui-lib",
-  "version": "7.0.5",
+  "version": "7.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudquery/plugin-config-ui-lib",
-      "version": "7.0.5",
+      "version": "7.1.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@babel/runtime": "^7.26.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cloudquery/plugin-config-ui-lib",
   "description": "Plugin configuration UI library for CloudQuery Cloud App",
-  "version": "7.0.5",
+  "version": "7.1.0",
   "private": false,
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/configs/vite.config.app.js
+++ b/src/configs/vite.config.app.js
@@ -10,7 +10,10 @@ const monacoEditorPlugin = monacoEditorVitePlugin.default;
 const envVariables = {};
 
 for (const key of Object.keys(process.env)) {
-  if (key.startsWith('REACT_APP') && process.env[key] !== undefined) {
+  if (
+    (key.startsWith('REACT_APP_') || key.startsWith('VERCEL_')) &&
+    process.env[key] !== undefined
+  ) {
     envVariables[key] = process.env[key];
   }
 }

--- a/src/utils/getPluginProps.ts
+++ b/src/utils/getPluginProps.ts
@@ -12,6 +12,6 @@ export function getPluginProps() {
     team: process.env.REACT_APP_PLUGIN_TEAM,
     kind: process.env.REACT_APP_PLUGIN_KIND,
     name: process.env.REACT_APP_PLUGIN_NAME,
-    version: process.env.REACT_APP_PLUGIN_VERSION,
+    version: (window as any).REACT_APP_PLUGIN_VERSION || process.env.REACT_APP_PLUGIN_VERSION,
   };
 }

--- a/src/utils/getPluginProps.ts
+++ b/src/utils/getPluginProps.ts
@@ -12,8 +12,9 @@ export function getPluginProps() {
     team: process.env.REACT_APP_PLUGIN_TEAM,
     kind: process.env.REACT_APP_PLUGIN_KIND,
     name: process.env.REACT_APP_PLUGIN_NAME,
-    version: process.env.REACT_APP_IS_PREVIEW
-      ? (window as any).REACT_APP_PLUGIN_VERSION || process.env.REACT_APP_PLUGIN_VERSION
-      : process.env.REACT_APP_PLUGIN_VERSION,
+    version:
+      process.env.VERCEL_ENV || process.env.NODE_ENV === 'development'
+        ? (window as any).REACT_APP_PLUGIN_VERSION || process.env.REACT_APP_PLUGIN_VERSION
+        : process.env.REACT_APP_PLUGIN_VERSION,
   };
 }

--- a/src/utils/getPluginProps.ts
+++ b/src/utils/getPluginProps.ts
@@ -12,6 +12,8 @@ export function getPluginProps() {
     team: process.env.REACT_APP_PLUGIN_TEAM,
     kind: process.env.REACT_APP_PLUGIN_KIND,
     name: process.env.REACT_APP_PLUGIN_NAME,
-    version: (window as any).REACT_APP_PLUGIN_VERSION || process.env.REACT_APP_PLUGIN_VERSION,
+    version: process.env.REACT_APP_IS_REVIEW
+      ? (window as any).REACT_APP_PLUGIN_VERSION || process.env.REACT_APP_PLUGIN_VERSION
+      : process.env.REACT_APP_PLUGIN_VERSION,
   };
 }

--- a/src/utils/getPluginProps.ts
+++ b/src/utils/getPluginProps.ts
@@ -12,7 +12,7 @@ export function getPluginProps() {
     team: process.env.REACT_APP_PLUGIN_TEAM,
     kind: process.env.REACT_APP_PLUGIN_KIND,
     name: process.env.REACT_APP_PLUGIN_NAME,
-    version: process.env.REACT_APP_IS_REVIEW
+    version: process.env.REACT_APP_IS_PREVIEW
       ? (window as any).REACT_APP_PLUGIN_VERSION || process.env.REACT_APP_PLUGIN_VERSION
       : process.env.REACT_APP_PLUGIN_VERSION,
   };


### PR DESCRIPTION
When Platform is deployed on Vercel, it can often have different version of the plugin from the latest one. This means that it will not be possible to test not merged plugin UI on any deployed Platform app. Therefore, we allow to use the dynamic value from window variable which allows the Platform app to pass the version it has to plugin UI. This will only be used in the Vercel environment or during development mode