### PR TITLE
Remove reactive values from useForm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudquery/plugin-config-ui-lib",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudquery/plugin-config-ui-lib",
-      "version": "8.1.0",
+      "version": "8.1.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@babel/runtime": "^7.27.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cloudquery/plugin-config-ui-lib",
   "description": "Plugin configuration UI library for CloudQuery Cloud App",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "private": false,
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/hooks/useConfigUIForm.ts
+++ b/src/hooks/useConfigUIForm.ts
@@ -20,7 +20,6 @@ export const useConfigUIForm = () => {
 
   const form = useForm({
     defaultValues,
-    values: defaultValues,
     resolver: formValidationResolver,
   });
 


### PR DESCRIPTION
With reactive values being in place, any changes to the config lead to `defaultValues` object being regenerated and thus updating the current form values